### PR TITLE
Improve tablet navigation and chat drawer UX

### DIFF
--- a/core/ui/src/main/java/io/androllm/core/ui/components/CloudAdaptiveNavigation.kt
+++ b/core/ui/src/main/java/io/androllm/core/ui/components/CloudAdaptiveNavigation.kt
@@ -84,7 +84,7 @@ fun CloudAdaptiveNavigation(
         WindowWidthSizeClass.Compact
     }
 
-    if (widthClass == WindowWidthSizeClass.Expanded || widthClass == WindowWidthSizeClass.Medium) {
+    if (widthClass == WindowWidthSizeClass.Expanded) {
         Row(modifier = Modifier.fillMaxSize()) {
             CloudNavigationRail(
                 currentRoute = currentRoute,

--- a/core/ui/src/main/java/io/androllm/core/ui/components/CloudBottomNavigationBar.kt
+++ b/core/ui/src/main/java/io/androllm/core/ui/components/CloudBottomNavigationBar.kt
@@ -78,7 +78,10 @@ fun CloudBottomNavigationBar(
         modifier = modifier
             .fillMaxWidth()
             .navigationBarsPadding()
-            .padding(horizontal = 20.dp, vertical = 10.dp),
+            .padding(start = 20.dp,
+                end = 20.dp,
+                top = 10.dp,
+                bottom = 0.dp),
         contentAlignment = Alignment.Center
     ) {
         BoxWithConstraints(
@@ -96,7 +99,7 @@ fun CloudBottomNavigationBar(
         ) {
             val tabWidth = maxWidth / tabCount
             val itemWidth = tabWidth
-            val itemHeight = maxHeight - 12.dp
+            val itemHeight = maxHeight - 3.dp
             val indicatorOffset by animateDpAsState(
                 targetValue = tabWidth * selectedIndex,
                 animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),

--- a/feature/chat/src/main/java/io/androllm/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/io/androllm/feature/chat/ChatScreen.kt
@@ -222,9 +222,17 @@ fun ChatScreen(
                 viewModel.toggleSearch(true)
                 scope.launch { drawerState.close() }
             },
+            onHomeClick = {
+                navController.navigate("home") {
+                    launchSingleTop = true
+                }
+                scope.launch { drawerState.close() }
+            },
             onOpenSettings = {
                 navController.navigate("settings")
+
                 scope.launch { drawerState.close() }
+
             }
         )
     }

--- a/feature/chat/src/main/java/io/androllm/feature/chat/ui/drawer/ConversationDrawer.kt
+++ b/feature/chat/src/main/java/io/androllm/feature/chat/ui/drawer/ConversationDrawer.kt
@@ -85,6 +85,7 @@ fun ConversationDrawerContent(
     onDeleteChat: (Conversation) -> Unit,
     onOpenSearch: () -> Unit,
     onOpenSettings: () -> Unit,
+    onHomeClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     ModalDrawerSheet(
@@ -102,9 +103,20 @@ fun ConversationDrawerContent(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    io.androllm.core.ui.components.CloudBugdroidLogo(size = 28.dp, showMoon = false)
+                Row(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable { onHomeClick() }
+                        .padding(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    io.androllm.core.ui.components.CloudBugdroidLogo(
+                        size = 28.dp,
+                        showMoon = false
+                    )
+
                     Spacer(modifier = Modifier.width(10.dp))
+
                     Column {
                         Text(
                             text = "AndroLLM",


### PR DESCRIPTION
## Summary

Improves navigation behavior and layout on tablets and adds a convenient Home shortcut to the chat drawer.

## Changes

- Use the bottom navigation bar on medium-width/tablet layouts instead of the navigation rail.
- Adjust the active navigation indicator to correctly fill each tab area.
- Improve bottom navigation spacing around the Android system navigation area.
- Make the AndroLLM logo/wordmark in the chat drawer clickable and navigate to Home.
- Close the chat drawer automatically after navigating Home.

## Tested on

- Lenovo TB-9707F
- Android 13
- Portrait and landscape/tablet layouts

The changes were tested locally and the updated navigation behavior works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clickable home destination to the conversation drawer’s logo and branding area.
  * Selecting Home now closes the drawer and returns to the home screen.

* **UI Improvements**
  * Medium-width layouts now use bottom navigation instead of the floating navigation rail.
  * Refined bottom navigation spacing and increased the active item height for improved visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->